### PR TITLE
Tune default leakyReLU

### DIFF
--- a/torch_points3d/core/base_conv/dense.py
+++ b/torch_points3d/core/base_conv/dense.py
@@ -113,7 +113,7 @@ class BaseDenseConvolutionUp(BaseConvolution):
 
 
 class DenseFPModule(BaseDenseConvolutionUp):
-    def __init__(self, up_conv_nn, bn=True, bias=False, activation=torch.nn.LeakyReLU(negative_slope=0.1), **kwargs):
+    def __init__(self, up_conv_nn, bn=True, bias=False, activation=torch.nn.LeakyReLU(negative_slope=0.01), **kwargs):
         super(DenseFPModule, self).__init__(None, **kwargs)
 
         self.nn = MLP2D(up_conv_nn, bn=bn, activation=activation, bias=False)
@@ -137,7 +137,7 @@ class DenseFPModule(BaseDenseConvolutionUp):
 
 
 class GlobalDenseBaseModule(torch.nn.Module):
-    def __init__(self, nn, aggr="max", bn=True, activation=torch.nn.LeakyReLU(negative_slope=0.1), **kwargs):
+    def __init__(self, nn, aggr="max", bn=True, activation=torch.nn.LeakyReLU(negative_slope=0.01), **kwargs):
         super(GlobalDenseBaseModule, self).__init__()
         self.nn = MLP2D(nn, bn=bn, activation=activation, bias=False)
         if aggr.lower() not in ["mean", "max"]:

--- a/torch_points3d/core/common_modules/dense_modules.py
+++ b/torch_points3d/core/common_modules/dense_modules.py
@@ -3,7 +3,7 @@ from .base_modules import Seq
 
 
 class Conv2D(Seq):
-    def __init__(self, in_channels, out_channels, bias=True, bn=True, activation=nn.LeakyReLU(negative_slope=0.1)):
+    def __init__(self, in_channels, out_channels, bias=True, bn=True, activation=nn.LeakyReLU(negative_slope=0.01)):
         super().__init__()
         self.append(nn.Conv2d(in_channels, out_channels, kernel_size=(1, 1), stride=(1, 1), bias=bias))
         if bn:
@@ -13,7 +13,7 @@ class Conv2D(Seq):
 
 
 class Conv1D(Seq):
-    def __init__(self, in_channels, out_channels, bias=True, bn=True, activation=nn.LeakyReLU(negative_slope=0.1)):
+    def __init__(self, in_channels, out_channels, bias=True, bn=True, activation=nn.LeakyReLU(negative_slope=0.01)):
         super().__init__()
         self.append(nn.Conv1d(in_channels, out_channels, kernel_size=1, bias=bias))
         if bn:
@@ -23,7 +23,7 @@ class Conv1D(Seq):
 
 
 class MLP2D(Seq):
-    def __init__(self, channels, bias=False, bn=True, activation=nn.LeakyReLU(negative_slope=0.1)):
+    def __init__(self, channels, bias=False, bn=True, activation=nn.LeakyReLU(negative_slope=0.01)):
         super().__init__()
         for i in range(len(channels) - 1):
             self.append(Conv2D(channels[i], channels[i + 1], bn=bn, bias=bias, activation=activation))

--- a/torch_points3d/modules/RSConv/dense.py
+++ b/torch_points3d/modules/RSConv/dense.py
@@ -21,7 +21,7 @@ class RSConvMapper(nn.Module):
         and the features of RSConv]
     """
 
-    def __init__(self, down_conv_nn, use_xyz, bn=True, activation=nn.LeakyReLU(negative_slope=0.1), *args, **kwargs):
+    def __init__(self, down_conv_nn, use_xyz, bn=True, activation=nn.LeakyReLU(negative_slope=0.01), *args, **kwargs):
         super(RSConvMapper, self).__init__()
 
         self._down_conv_nn = down_conv_nn

--- a/torch_points3d/modules/pointnet2/dense.py
+++ b/torch_points3d/modules/pointnet2/dense.py
@@ -16,7 +16,7 @@ class PointNetMSGDown(BaseDenseConvolutionDown):
         nsample=None,
         down_conv_nn=None,
         bn=True,
-        activation=torch.nn.LeakyReLU(negative_slope=0.1),
+        activation=torch.nn.LeakyReLU(negative_slope=0.01),
         use_xyz=True,
         **kwargs
     ):


### PR DESCRIPTION
We lost 3% on s3dis with PN2 just because of changing from ReLU to LeakyReLU(0.1)... Putting the default to 0.01 brings the results back to previous scores, what do you think?