### PR TITLE
added fix for kernel image fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,14 @@ rm -rf ~/.cache/pip
 poetry install
 ```
 
+#### CUDA kernel failed : no kernel image is available for execution on the device
+
+This can happen when trying to run the code on a different GPU than the one used to compile the `torch-points-kernels` library. Uninstall `torch-points-kernels`, clear cache, and reinstall after setting the `TORCH_CUDA_ARCH_LIST` environment variable. For example, for compiling with a Tesla T4 (Turing 7.5) and running the code on a Tesla V100 (Volta 7.0) use:
+```
+export TORCH_CUDA_ARCH_LIST="7.0;7.5"
+```
+See [this useful chart](http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/) for more architecture compatibility.
+
 ## Contributing
 
 Contributions are welcome! The only asks are that you stick to the styling and that you add tests as you add more features!


### PR DESCRIPTION
Documented the crash that can happen when compiling with different GPUs, + a fix and a link to a list of architecture.

This is not an issue specific to this repo in particular, but torch-points-kernels does fail when using Turing -> Volta, and it is not well documented elsewhere.