### PR TITLE
Enabled visualization on pointnet, pointnet2, rsconv

### DIFF
--- a/notebooks/dashboard.ipynb
+++ b/notebooks/dashboard.ipynb
@@ -143,7 +143,10 @@
    "outputs": [],
    "source": [
     "def update_model_name(event):\n",
-    "    selector_paths.options = experiment_manager.get_model_wviz_paths(model_name.value)\n",
+    "    old_value = selector_paths.value\n",
+    "    selector_paths.options = experiment_manager.get_model_wviz_paths(selector_model_name.value)\n",
+    "    if old_value == selector_epoch.value:\n",
+    "        update_epoch(event)\n",
     "selector_model_name.param.watch(update_model_name, 'value')\n",
     "\n",
     "def update_model_path(event):\n",

--- a/torch_points3d/models/segmentation/pointnet.py
+++ b/torch_points3d/models/segmentation/pointnet.py
@@ -18,6 +18,8 @@ class PointNet(BaseModel):
         self.pointnet_seg = PointNetSeg(**flatten_dict(opt))
         self._is_dense = ConvolutionFormatFactory.check_is_dense_format(self.conv_type)
 
+        self.visual_names = ["data_visual"]
+
     def set_input(self, data, device):
         data = data.to(device)
         self.input = data
@@ -34,6 +36,9 @@ class PointNet(BaseModel):
                 F.nll_loss(self.output, self.labels, ignore_index=IGNORE_LABEL)
                 + (internal_loss if internal_loss.item() != 0 else 0) * 0.001
             )
+
+        self.data_visual = self.input
+        self.data_visual.pred = torch.max(self.output, -1)[1]
         return self.output
 
     def backward(self):

--- a/torch_points3d/models/segmentation/pointnet2.py
+++ b/torch_points3d/models/segmentation/pointnet2.py
@@ -60,6 +60,8 @@ class PointNet2_D(UnetBasedModel):
         self.FC_layer.append(Conv1D(last_mlp_opt.nn[-1], self._num_classes, activation=None, bias=True, bn=False))
         self.loss_names = ["loss_seg"]
 
+        self.visual_names = ["data_visual"]
+
     def set_input(self, data, device):
         """Unpack input data from the dataloader and perform necessary pre-processing steps.
         Parameters:
@@ -105,6 +107,10 @@ class PointNet2_D(UnetBasedModel):
             self.loss_seg = F.cross_entropy(
                 self.output, self.labels, weight=self._weight_classes, ignore_index=IGNORE_LABEL
             )
+
+        self.data_visual = self.input
+        self.data_visual.y = torch.reshape(self.labels, data.pos.shape[0:2])
+        self.data_visual.pred = torch.max(self.output, -1)[1].reshape(data.pos.shape[0:2])
         return self.output
 
     def backward(self):

--- a/torch_points3d/models/segmentation/rsconv.py
+++ b/torch_points3d/models/segmentation/rsconv.py
@@ -43,6 +43,8 @@ class RSConvLogicModel(UnwrappedUnetBasedModel):
         self.FC_layer.append(Conv1D(last_mlp_opt.nn[-1], self._num_classes, activation=None, bias=True, bn=False))
         self.loss_names = ["loss_seg"]
 
+        self.visual_names = ["data_visual"]
+
     def set_input(self, data, device):
         """Unpack input data from the dataloader and perform necessary pre-processing steps.
         Parameters:
@@ -108,6 +110,10 @@ class RSConvLogicModel(UnwrappedUnetBasedModel):
 
         if self.labels is not None:
             self.loss_seg = F.cross_entropy(self.output, self.labels, weight=self._weight_classes)
+
+        self.data_visual = self.input
+        self.data_visual.y = torch.reshape(self.labels, data.pos.shape[0:2])
+        self.data_visual.pred = torch.max(self.output, -1)[1].reshape(data.pos.shape[0:2])
 
         return self.output
 

--- a/torch_points3d/visualization/visualizer.py
+++ b/torch_points3d/visualization/visualizer.py
@@ -154,7 +154,7 @@ class Visualizer(object):
             for idx in np.argwhere(self._seen_batch == batch_indices).flatten():
                 pos_idx = pos_indices[idx]
                 for visual_name, item in visuals.items():
-                    if hasattr(item, "batch"):  # The PYG dataloader has been used
+                    if hasattr(item, "batch") and item.batch is not None:  # The PYG dataloader has been used
                         out_item = self._extract_from_PYG(item, pos_idx)
                     else:
                         out_item = self._extract_from_dense(item, pos_idx)


### PR DESCRIPTION
Enabled visualizations to be used on segmentation of pointnet, pointnet2 and rsconv. Also, added a fix to the dashbord notebook dealing with changing the model path.