### PR TITLE
Windows Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Segmentation: KPConv on scannetV2
   - Object Detection: VoteNet on scannetV2
 - Add VoteNet Paper / Backbones within API
+- Windows support
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,11 @@ export TORCH_CUDA_ARCH_LIST="7.0;7.5"
 ```
 See [this useful chart](http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/) for more architecture compatibility.
 
+#### Cannot use wandb on Windows
+
+Raises `OSError: [WinError 6] The handle is invalid` / `wandb: ERROR W&B process failed to launch`
+Wandb is currently broken on Windows (see [this issue](https://github.com/wandb/client/issues/862)), a workaround is to use the command line argument `wandb.log=false`
+
 ## Contributing
 
 Contributions are welcome! The only asks are that you stick to the styling and that you add tests as you add more features!

--- a/torch_points3d/datasets/base_dataset.py
+++ b/torch_points3d/datasets/base_dataset.py
@@ -132,18 +132,16 @@ class BaseDataset:
     def _get_collate_function(conv_type, is_multiscale):
         if is_multiscale:
             if conv_type.lower() == ConvolutionFormat.PARTIAL_DENSE.value.lower():
-                return lambda datalist: MultiScaleBatch.from_data_list(datalist)
+                return MultiScaleBatch.from_data_list
             else:
                 raise NotImplementedError(
                     "MultiscaleTransform is activated and supported only for partial_dense format"
                 )
-
         is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
         if is_dense:
-            return lambda datalist: SimpleBatch.from_data_list(datalist)
+            return SimpleBatch.from_data_list
         else:
-            return lambda datalist: torch_geometric.data.batch.Batch.from_data_list(datalist)
-
+            return torch_geometric.data.batch.Batch.from_data_list
     @staticmethod
     def get_num_samples(batch, conv_type):
         is_dense = ConvolutionFormatFactory.check_is_dense_format(conv_type)
@@ -176,7 +174,7 @@ class BaseDataset:
 
         batch_collate_function = self.__class__._get_collate_function(conv_type, precompute_multi_scale)
         dataloader = partial(
-            torch.utils.data.DataLoader, collate_fn=batch_collate_function, worker_init_fn=lambda _: np.random.seed()
+            torch.utils.data.DataLoader, collate_fn=batch_collate_function, worker_init_fn=np.random.seed
         )
 
         if self.train_sampler:

--- a/torch_points3d/datasets/segmentation/shapenet.py
+++ b/torch_points3d/datasets/segmentation/shapenet.py
@@ -248,7 +248,7 @@ class ShapeNet(InMemoryDataset):
             path = osp.join(self.raw_dir, "train_test_split", f"shuffled_{split}_file_list.json")
             with open(path, "r") as f:
                 filenames = [
-                    osp.sep.join(name.split(osp.sep)[1:]) + ".txt" for name in json.load(f)
+                    osp.sep.join(name.split('/')[1:]) + ".txt" for name in json.load(f)
                 ]  # Removing first directory.
             data_raw_list, data_list = self._process_filenames(sorted(filenames))
             if split == "train" or split == "val":

--- a/torch_points3d/trainer.py
+++ b/torch_points3d/trainer.py
@@ -46,7 +46,7 @@ class Trainer:
 
         # Get device
         if self._cfg.training.cuda > -1 and torch.cuda.is_available():
-            device = "cuda" + str(self._cfg.training.cuda)
+            device = "cuda"
             torch.cuda.set_device(self._cfg.training.cuda)
         else:
             device = "cpu"


### PR DESCRIPTION
Multiprocessing cannot use lambdas on Windows due to limitations with pickle. Additionally wandb currently does not run correctly on Windows wandb/client#862 therefore we recommend disabling it in the troubleshooting section of the readme