### PR TITLE
correct registration metrics

### DIFF
--- a/test/test_registration_metrics.py
+++ b/test/test_registration_metrics.py
@@ -78,44 +78,15 @@ class TestRegistrationMetrics(unittest.TestCase):
         npt.assert_allclose(rre.item(), 30, rtol=1e-3)
 
     def test_compute_scaled_registration_error(self):
-        xyz = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, -1.0, 0.0]])
-        xyz_target = torch.tensor(
-            [[0.0, 0.0, 0.0], [42.0, 0.0, 0.0], [0.0, -1.0, 0.0], [125, -1.0, 1458.0], [1.0, 0.0, 0.0]]
-        )
-        match_gt = torch.tensor([[0, 4], [1, 0], [2, 2]], dtype=torch.long)
-        T_est = torch.eye(4)
-        err1 = compute_scaled_registration_error(xyz, xyz_target, match_gt, T_est)
-        self.assertAlmostEqual(err1.item(), 0.0)
-        e = -1.0  # error in one point
-        xyz = torch.tensor(
-            [
-                [1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [0.0, 0.0, 0.0],
-                [0.0, 2.0, 0.0],
-                [1.0, 2.0, 0.0],
-                [0.5, 1.5, 0.0],
-                [0.5, 2.5, 0.0],
-            ]
-        )
 
-        xyz_target = torch.tensor(
-            [
-                [1.0, 0.0, 0.0],
-                [0.0, 1.0, 0.0],
-                [1.0, 1.0, 0.0],
-                [0.0, 0.0, e],
-                [0.0, 2.0, 0.0],
-                [1.0, 2.0, 0.0],
-                [0.5, 1.5, 0.0],
-                [0.5, 2.5, 0.0],
-            ]
-        )
-        match_gt = torch.tensor([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4], [5, 5], [6, 6], [7, 7]], dtype=torch.long)
-        err2 = compute_scaled_registration_error(xyz, xyz_target, match_gt, T_est)
-        c = torch.norm(xyz.mean(axis=0), 2).item()
-        self.assertAlmostEqual(err2.item(), 1 / (8 * c))
+        xyz = torch.tensor([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 2.0, 0.0], [2.0, 0.0, 0.0],])
+        R_est = euler_angles_to_rotation_matrix(torch.tensor([0, 0, np.pi / 6]))
+        T_gt = torch.eye(4)
+        T_est = torch.eye(4)
+        T_est[:3, :3] = R_est
+        err = compute_scaled_registration_error(xyz, T_gt, T_est)
+        val = 0.55901
+        self.assertAlmostEqual(err.item(), val, places=5)
 
 
 if __name__ == "__main__":

--- a/torch_points3d/metrics/registration_metrics.py
+++ b/torch_points3d/metrics/registration_metrics.py
@@ -50,17 +50,17 @@ def compute_transfo_error(T_gt, T_pred):
     return rte, rre
 
 
-def compute_scaled_registration_error(xyz, xyz_target, match_gt, T_est, tol=1e-12):
+def compute_scaled_registration_error(xyz, T_gt, T_est, tol=1e-12):
     """
     compute the registration error as defined in:
     https://arxiv.org/pdf/2003.12841.pdf
     """
-    subxyz = xyz[match_gt[:, 0]] @ T_est[:3, :3].T + T_est[:3, 3]
-    subxyz_target = xyz_target[match_gt[:, 1]]
-    centroid = subxyz.mean(axis=0)
+    xyz_est = xyz @ T_est[:3, :3].T + T_est[:3, 3]
+    xyz_gt = xyz @ T_gt[:3, :3].T + T_gt[:3, 3]
+    centroid = xyz_est.mean(axis=0)
 
-    dist1 = torch.sqrt(torch.sum((subxyz - subxyz_target) ** 2, axis=-1))
-    dist2 = torch.sqrt(torch.sum((subxyz - centroid) ** 2, axis=-1))
+    dist1 = torch.sqrt(torch.sum((xyz_est - xyz_gt) ** 2, axis=-1))
+    dist2 = torch.sqrt(torch.sum((xyz_est - centroid) ** 2, axis=-1))
 
     err = torch.mean(dist1 / (dist2 + tol))
     return err

--- a/torch_points3d/metrics/registration_tracker.py
+++ b/torch_points3d/metrics/registration_tracker.py
@@ -140,7 +140,7 @@ it measures loss, feature match recall, hit ratio, rotation error, translation e
 
                 trans_error, rot_error = compute_transfo_error(T_pred, T_gt)
 
-                sr_err = compute_scaled_registration_error(xyz, xyz_target, matches_gt, T_pred)
+                sr_err = compute_scaled_registration_error(xyz, T_gt, T_pred)
                 self._hit_ratio.add(hit_ratio.item())
                 self._feat_match_ratio.add(float(hit_ratio.item() > self.tau_2))
                 self._trans_error.add(trans_error.item())


### PR DESCRIPTION
After the kind review of @simonefontana see [here](https://github.com/nicolas-chaulet/torch-points3d/pull/420/files#diff-53d25a103d926241da472e184972f24e) for more details, I corrected the metric. It is explained at the section 3.3 of [this article](https://arxiv.org/pdf/2003.12841.pdf).