### PR TITLE
Change _forward_sparse

### DIFF
--- a/torch_points3d/core/common_modules/base_modules.py
+++ b/torch_points3d/core/common_modules/base_modules.py
@@ -142,7 +142,7 @@ class FastBatchNorm1d(BaseModule):
         x = x.transpose(0, 2)
         x = self.batch_norm(x)
         x = x.transpose(0, 2)
-        return x.squeeze()
+        return x.squeeze(dim=2)
 
     def forward(self, x):
         if x.dim() == 2:


### PR DESCRIPTION
Changes _forward_sparse() s.t. [N,1] tensors are output as [N,1] tensors instead of [N] #428 