### PR TITLE
Saving dataset properties to the checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Bug fix
+
+- Dataset configurations are saved in the checkpoints so that models can be created without requiring the actual dataset
+- BatchNorm1d fix
+
 ### Changed
 
 - More general API for Minkowski with support for Bottleneck blocks and Squeeze and excite.

--- a/forward_scripts/forward.py
+++ b/forward_scripts/forward.py
@@ -76,14 +76,17 @@ def main(cfg):
     if cfg.data:
         for key, value in cfg.data.items():
             checkpoint.data_config.update(key, value)
+    if cfg.dataset_config:
+        for key, value in cfg.dataset_config.items():
+            checkpoint.dataset_properties.update(key, value)
 
     # Create dataset and mdoel
-    dataset = instantiate_dataset(checkpoint.data_config)
-    model = checkpoint.create_model(dataset, weight_name=cfg.weight_name)
+    model = checkpoint.create_model(checkpoint.dataset_properties, weight_name=cfg.weight_name)
     log.info(model)
     log.info("Model size = %i", sum(param.numel() for param in model.parameters() if param.requires_grad))
 
     # Set dataloaders
+    dataset = instantiate_dataset(checkpoint.data_config)
     dataset.create_dataloaders(
         model, cfg.batch_size, cfg.shuffle, cfg.num_workers, False,
     )

--- a/test/test_model_checkpoint.py
+++ b/test/test_model_checkpoint.py
@@ -119,6 +119,23 @@ class TestModelCheckpoint(unittest.TestCase):
         self.assertEqual(ckp["models"]["best_acc"]["state"].item(), optimal_state)
         self.assertEqual(ckp["models"]["latest"]["state"].item(), model.state.item())
 
+    def test_dataset_properties(self):
+        self.run_path = os.path.join(DIR, "checkpt")
+        if not os.path.exists(self.run_path):
+            os.makedirs(self.run_path)
+
+        model_checkpoint = ModelCheckpoint(self.run_path, self.model_name, "test", run_config=self.config, resume=False)
+        model_checkpoint.dataset_properties = {"first": 1, "num_classes": 20}
+        model = MockModel()
+        metric_func = {"acc": max}
+        mock_metrics = {"current_metrics": {"acc": 12}, "stage": "test", "epoch": 10}
+        metric_func = {"acc": max}
+        model_checkpoint.save_best_models_under_current_metrics(model, mock_metrics, metric_func)
+
+        ckp = ModelCheckpoint(self.run_path, self.model_name, "test", run_config=self.config, resume=False)
+
+        self.assertEqual(ckp.dataset_properties, model_checkpoint.dataset_properties)
+
     def tearDown(self):
         if os.path.exists(self.run_path):
             shutil.rmtree(self.run_path)

--- a/torch_points3d/applications/pretrained_api.py
+++ b/torch_points3d/applications/pretrained_api.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import urllib.request
+from omegaconf import DictConfig
 
 # Import building function for model and dataset
 from torch_points3d.datasets.dataset_factory import instantiate_dataset
@@ -117,7 +118,7 @@ class PretainedRegistry(object):
                 CHECKPOINT_DIR, model_tag, weight_name if weight_name is not None else "latest", resume=False,
             )
             if mock_dataset:
-                dataset = checkpoint.dataset_properties.copy()
+                dataset = DictConfig(checkpoint.dataset_properties.copy())
                 if PretainedRegistry.MOCK_USED_PROPERTIES.get(model_tag) is not None:
                     for k, v in PretainedRegistry.MOCK_USED_PROPERTIES.get(model_tag).items():
                         dataset[k] = v

--- a/torch_points3d/applications/pretrained_api.py
+++ b/torch_points3d/applications/pretrained_api.py
@@ -117,7 +117,7 @@ class PretainedRegistry(object):
                 CHECKPOINT_DIR, model_tag, weight_name if weight_name is not None else "latest", resume=False,
             )
             if mock_dataset:
-                dataset = checkpoint.data_config
+                dataset = checkpoint.dataset_properties.copy()
                 if PretainedRegistry.MOCK_USED_PROPERTIES.get(model_tag) is not None:
                     for k, v in PretainedRegistry.MOCK_USED_PROPERTIES.get(model_tag).items():
                         dataset[k] = v

--- a/torch_points3d/metrics/model_checkpoint.py
+++ b/torch_points3d/metrics/model_checkpoint.py
@@ -32,6 +32,7 @@ class Checkpoint:
         self.stats: Dict[str, List[Any]] = {"train": [], "test": [], "val": []}
         self.optimizer: Optional[Tuple[str, Any]] = None
         self.schedulers: Dict[str, Any] = {}
+        self.dataset_properties: Dict[str, Any] = {}
 
     def save_objects(self, models_to_save: Dict[str, Any], stage, current_stat, optimizer, schedulers, **kwargs):
         """ Saves checkpoint with updated mdoels for the given stage
@@ -219,6 +220,14 @@ class ModelCheckpoint(object):
     @property
     def checkpoint_path(self):
         return self._checkpoint.path
+
+    @property
+    def dataset_properties(self) -> Dict[str, Any]:
+        return self._checkpoint.dataset_properties
+
+    @dataset_properties.setter
+    def dataset_properties(self, dataset_properties: Dict[str, Any]):
+        self._checkpoint.dataset_properties = dataset_properties
 
     def get_starting_epoch(self):
         return len(self._checkpoint.stats["train"]) + 1

--- a/torch_points3d/metrics/segmentation_tracker.py
+++ b/torch_points3d/metrics/segmentation_tracker.py
@@ -44,6 +44,7 @@ class SegmentationTracker(BaseTracker):
         self._acc = 0
         self._macc = 0
         self._miou = 0
+        self._miou_per_class = {}
 
     @staticmethod
     def detach_tensor(tensor):
@@ -84,6 +85,10 @@ class SegmentationTracker(BaseTracker):
         self._acc = 100 * self._confusion_matrix.get_overall_accuracy()
         self._macc = 100 * self._confusion_matrix.get_mean_class_accuracy()
         self._miou = 100 * self._confusion_matrix.get_average_intersection_union()
+        self._miou_per_class = {
+            i: "{:.2f}".format(100 * v)
+            for i, v in enumerate(self._confusion_matrix.get_intersection_union_per_class()[0])
+        }
 
     def get_metrics(self, verbose=False) -> Dict[str, Any]:
         """ Returns a dictionnary of all metrics and losses being tracked
@@ -93,6 +98,9 @@ class SegmentationTracker(BaseTracker):
         metrics["{}_acc".format(self._stage)] = self._acc
         metrics["{}_macc".format(self._stage)] = self._macc
         metrics["{}_miou".format(self._stage)] = self._miou
+
+        if verbose:
+            metrics["{}_miou_per_class".format(self._stage)] = self._miou_per_class
         return metrics
 
     @property

--- a/torch_points3d/trainer.py
+++ b/torch_points3d/trainer.py
@@ -93,6 +93,7 @@ class Trainer:
                 )
             self._model: BaseModel = instantiate_model(copy.deepcopy(self._cfg), self._dataset)
             self._model.instantiate_optimizers(self._cfg)
+        self._checkpoint.dataset_properties = self._dataset.used_properties
 
         log.info(self._model)
         self._model.log_optimizers()


### PR DESCRIPTION
This change is required to make sure that a model can be recreated form the checkpoint only. Properties were stored in the dataset but never saved to the checkpoint. They are different from dataset configs in the sense that they capture the properties that model needs from the dataset to be created. Dataset configs are the configs that the dataset need. So I kept them separated.