### PR TITLE
Pcr benchmark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Support for the IRALab benchmark (https://arxiv.org/abs/2003.12841), with data from the ETH, Canadian Planetary, Kaist and TUM datasets.
+
+
 ### Bug fix
 
 - Dataset configurations are saved in the checkpoints so that models can be created without requiring the actual dataset

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ where each folder contains the dataset related to each task.
 
 - **[3DMatch](http://3dmatch.cs.princeton.edu)** from Andy Zeng _et al._: [3DMatch: Learning Local Geometric Descriptors from RGB-D Reconstructions](https://arxiv.org/abs/1603.08182)
 
+- **[The IRALab Benchmark](https://github.com/iralabdisco/point_clouds_registration_benchmark)** from Simone Fontana _et al._:[A Benchmark for Point Clouds Registration Algorithms](https://arxiv.org/abs/2003.12841), which is composed of data from:
+    - [the ETH datasets](https://projects.asl.ethz.ch/datasets/doku.php?id=laserregistration:laserregistration);
+    - [the Canadian Planetary Emulation Terrain 3D Mapping datasets](http://asrl.utias.utoronto.ca/datasets/3dmap/index.html);
+    - [the TUM Vision Groud RGBD datasets](https://vision.in.tum.de/data/datasets/rgbd-dataset);
+    - [the KAIST Urban datasets](https://irap.kaist.ac.kr/dataset/).
+
 ### Classification
 
 - **[ModelNet](https://modelnet.cs.princeton.edu)** from Zhirong Wu _et al._: [3D ShapeNets: A Deep Representation for Volumetric Shapes](https://people.csail.mit.edu/khosla/papers/cvpr2015_wu.pdf)

--- a/conf/data/registration/testkaist.yaml
+++ b/conf/data/registration/testkaist.yaml
@@ -1,0 +1,78 @@
+data:
+  task: registration
+  class: testkaist.KaistDataset
+  dataroot: data
+  first_subsampling: 0.02
+  max_dist_overlap: 0.05
+  min_size_block: 1.5
+  max_size_block: 2
+  num_pos_pairs: 30000
+  min_points: 300
+  num_points: 5000
+  tau_1: 0.1
+  tau_2: 0.05
+  rot_thresh: 4
+  trans_thresh: 0.15
+  sym: True
+  pre_transforms:
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+  ss_transform:
+    - transform: CubeCrop
+      params:
+        c: 1
+    - transform: CubeCrop
+      params:
+        c: 1.5
+
+  train_transform:
+    - transform: SaveOriginalPosId
+    - transform: FixedPoints
+      lparams: [20000]
+    - transform: RandomNoise
+      params:
+        sigma: 0.01
+        clip: 0.05
+    - transform: Random3AxisRotation
+      params:
+        apply_rotation: True
+        rot_x: 360
+        rot_y: 360
+        rot_z: 360
+    - transform: RandomScaleAnisotropic
+      params:
+        scales: [0.9,1.2]
+    - transform: XYZFeature
+      params:
+        add_x: True
+        add_y: True
+        add_z: True
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+        quantize_coords: True
+        mode: "last"
+    - transform: ShiftVoxels
+    - transform: AddOnes
+    - transform: AddFeatByKey
+      params:
+        add_to_x: True
+        feat_name: 'ones'
+  test_transform:
+    - transform: SaveOriginalPosId
+    - transform: XYZFeature
+      params:
+        add_x: True
+        add_y: True
+        add_z: True
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+        quantize_coords: True
+        mode: "last"
+    - transform: AddOnes
+    - transform: AddFeatByKey
+      params:
+        add_to_x: True
+        feat_name: 'ones'

--- a/conf/data/registration/testtum.yaml
+++ b/conf/data/registration/testtum.yaml
@@ -1,0 +1,78 @@
+data:
+  task: registration
+  class: testtum.TUMDataset
+  dataroot: data
+  first_subsampling: 0.02
+  max_dist_overlap: 0.05
+  min_size_block: 1.5
+  max_size_block: 2
+  num_pos_pairs: 30000
+  min_points: 300
+  num_points: 5000
+  tau_1: 0.1
+  tau_2: 0.05
+  rot_thresh: 4
+  trans_thresh: 0.15
+  sym: True
+  pre_transforms:
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+  ss_transform:
+    - transform: CubeCrop
+      params:
+        c: 1
+    - transform: CubeCrop
+      params:
+        c: 1.5
+
+  train_transform:
+    - transform: SaveOriginalPosId
+    - transform: FixedPoints
+      lparams: [20000]
+    - transform: RandomNoise
+      params:
+        sigma: 0.01
+        clip: 0.05
+    - transform: Random3AxisRotation
+      params:
+        apply_rotation: True
+        rot_x: 360
+        rot_y: 360
+        rot_z: 360
+    - transform: RandomScaleAnisotropic
+      params:
+        scales: [0.9,1.2]
+    - transform: XYZFeature
+      params:
+        add_x: True
+        add_y: True
+        add_z: True
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+        quantize_coords: True
+        mode: "last"
+    - transform: ShiftVoxels
+    - transform: AddOnes
+    - transform: AddFeatByKey
+      params:
+        add_to_x: True
+        feat_name: 'ones'
+  test_transform:
+    - transform: SaveOriginalPosId
+    - transform: XYZFeature
+      params:
+        add_x: True
+        add_y: True
+        add_z: True
+    - transform: GridSampling3D
+      params:
+        size: ${data.first_subsampling}
+        quantize_coords: True
+        mode: "last"
+    - transform: AddOnes
+    - transform: AddFeatByKey
+      params:
+        add_to_x: True
+        feat_name: 'ones'

--- a/docs/src/advanced.rst
+++ b/docs/src/advanced.rst
@@ -358,6 +358,17 @@ Registration
 http://3dmatch.cs.princeton.edu/
 
 
+IRALab Benchmark
+"""""""""""""""""""
+
+https://arxiv.org/abs/2003.12841 composed of data from:
+
+:the ETH datasets: https://projects.asl.ethz.ch/datasets/doku.php?id=laserregistration:laserregistration
+:the Canadian Planetary Emulation Terrain 3D Mapping datasets: http://asrl.utias.utoronto.ca/datasets/3dmap/index.html
+:the TUM Vision Groud RGBD datasets: https://vision.in.tum.de/data/datasets/rgbd-dataset
+:the KAIST Urban datasets: https://irap.kaist.ac.kr/dataset
+
+
 Model checkpoint
 ------------------
 

--- a/docs/src/advanced.rst
+++ b/docs/src/advanced.rst
@@ -363,10 +363,10 @@ IRALab Benchmark
 
 https://arxiv.org/abs/2003.12841 composed of data from:
 
-:the ETH datasets: https://projects.asl.ethz.ch/datasets/doku.php?id=laserregistration:laserregistration
-:the Canadian Planetary Emulation Terrain 3D Mapping datasets: http://asrl.utias.utoronto.ca/datasets/3dmap/index.html
-:the TUM Vision Groud RGBD datasets: https://vision.in.tum.de/data/datasets/rgbd-dataset
-:the KAIST Urban datasets: https://irap.kaist.ac.kr/dataset
+* the ETH datasets (https://projects.asl.ethz.ch/datasets/doku.php?id=laserregistration:laserregistration)
+* the Canadian Planetary Emulation Terrain 3D Mapping datasets (http://asrl.utias.utoronto.ca/datasets/3dmap/index.html)
+* the TUM Vision Groud RGBD datasets (https://vision.in.tum.de/data/datasets/rgbd-dataset)
+* the KAIST Urban datasets (https://irap.kaist.ac.kr/dataset)
 
 
 Model checkpoint

--- a/torch_points3d/datasets/registration/testkaist.py
+++ b/torch_points3d/datasets/registration/testkaist.py
@@ -1,0 +1,106 @@
+"""
+Code taken from
+https://github.com/iralabdisco/point_clouds_registration_benchmark/blob/master/kaist_setup.py
+"""
+import gdown
+import os
+import logging
+import sys
+
+from zipfile import ZipFile
+
+from torch_points3d.datasets.registration.basetest import BasePCRBTest
+from torch_points3d.datasets.base_dataset import BaseDataset
+from torch_points3d.datasets.registration.base_siamese_dataset import BaseSiameseDataset
+
+from torch_points3d.datasets.registration.utils import files_exist
+from torch_points3d.datasets.registration.utils import makedirs
+
+log = logging.getLogger(__name__)
+
+class TestPairKaist(BasePCRBTest):
+    DATASETS = [["urban05","https://drive.google.com/uc?id=1rm8XOroaLVPDwSAVZJk05aIVRTMvdoxF"]]
+
+    def __init__(self, root,
+                 transform=None,
+                 pre_transform=None,
+                 pre_filter=None,
+                 verbose=False,
+                 debug=False,
+                 num_pos_pairs=200,
+                 max_dist_overlap=0.01,
+                 self_supervised=False,
+                 min_size_block=2,
+                 max_size_block=3,
+                 min_points=500,
+                 ss_transform=None):
+        self.link_pairs = "https://cloud.mines-paristech.fr/index.php/s/4cTpY4CKPAXFGk4/download"
+        
+        BasePCRBTest.__init__(self,
+                              root=root,
+                              transform=transform,
+                              pre_transform=pre_transform,
+                              pre_filter=pre_filter,
+                              verbose=verbose, debug=debug,
+                              max_dist_overlap=max_dist_overlap,
+                              num_pos_pairs=num_pos_pairs,
+                              self_supervised=self_supervised,
+                              min_size_block=min_size_block,
+                              max_size_block=max_size_block,
+                              min_points=min_points,
+                              ss_transform=ss_transform)
+
+    def download(self):
+        folder = os.path.join(self.raw_dir, "test")
+        if files_exist([folder]):  # pragma: no cover
+            log.warning("already downloaded {}".format("test"))
+            return
+        else:
+            makedirs(folder)
+        log.info("Download elements in the file {}...".format(folder))
+        for name, url in self.DATASETS:
+            dataset_folder = os.path.join(folder,name)
+            # os.mkdir(dataset_folder)
+            log.info(f'Downloading sequence {name}')
+            filename = os.path.join(folder,name+".zip")
+            gdown.download(url, filename, quiet=False)
+            with ZipFile(filename, 'r') as zip_obj:
+                zip_obj.extractall(folder)
+            os.remove(filename)
+
+        self.download_pairs(folder)
+
+
+class KaistDataset(BaseSiameseDataset):
+    """
+    this class is a dataset for testing registration algorithm on the Kaist urban dataset
+    https://irap.kaist.ac.kr/dataset/
+    as defined in https://github.com/iralabdisco/point_clouds_registration_benchmark.
+    """
+
+
+    def __init__(self, dataset_opt):
+
+        super().__init__(dataset_opt)
+        pre_transform = self.pre_transform
+        train_transform = self.train_transform
+        ss_transform = getattr(self, "ss_transform", None)
+        test_transform = self.test_transform
+
+        # training is similar to test but only unsupervised training is allowed XD
+        self.train_dataset = TestPairKaist(root=self._data_path,
+                                         pre_transform=pre_transform,
+                                         transform=train_transform,
+                                         max_dist_overlap=dataset_opt.max_dist_overlap,
+                                         self_supervised=True,
+                                         min_size_block=dataset_opt.min_size_block,
+                                         max_size_block=dataset_opt.max_size_block,
+                                         num_pos_pairs=dataset_opt.num_pos_pairs,
+                                         min_points=dataset_opt.min_points,
+                                         ss_transform=ss_transform)
+        self.test_dataset = TestPairKaist(root=self._data_path,
+                                        pre_transform=pre_transform,
+                                        transform=test_transform,
+                                        max_dist_overlap=dataset_opt.max_dist_overlap,
+                                        num_pos_pairs=dataset_opt.num_pos_pairs,
+                                        self_supervised=False)

--- a/torch_points3d/datasets/registration/testkaist.py
+++ b/torch_points3d/datasets/registration/testkaist.py
@@ -59,8 +59,6 @@ class TestPairKaist(BasePCRBTest):
             makedirs(folder)
         log.info("Download elements in the file {}...".format(folder))
         for name, url in self.DATASETS:
-            dataset_folder = os.path.join(folder,name)
-            # os.mkdir(dataset_folder)
             log.info(f'Downloading sequence {name}')
             filename = os.path.join(folder,name+".zip")
             gdown.download(url, filename, quiet=False)

--- a/torch_points3d/datasets/registration/testtum.py
+++ b/torch_points3d/datasets/registration/testtum.py
@@ -1,0 +1,110 @@
+"""
+Code taken from
+https://github.com/iralabdisco/point_clouds_registration_benchmark/blob/master/tum_setup.py
+"""
+import gdown
+import os
+import logging
+import sys
+
+from zipfile import ZipFile
+
+from torch_points3d.datasets.registration.basetest import BasePCRBTest
+from torch_points3d.datasets.base_dataset import BaseDataset
+from torch_points3d.datasets.registration.base_siamese_dataset import BaseSiameseDataset
+
+# from torch_points3d.metrics.registration_tracker import FragmentRegistrationTracker
+
+from torch_points3d.datasets.registration.utils import files_exist
+from torch_points3d.datasets.registration.utils import makedirs
+
+log = logging.getLogger(__name__)
+
+class TestPairTUM(BasePCRBTest):
+    DATASETS = [["long_office_household","https://drive.google.com/uc?id=1Uy9aUyZbjW26-lZ1oyqOUxJ9tP7E-fWP"],
+        ["pioneer_slam","https://drive.google.com/uc?id=1ha3rxXewWrlCv6SPbpg21I8Wpl9v9fi1"],
+        ["pioneer_slam3","https://drive.google.com/uc?id=1L8FzuFf1Nc3hy6YfhHYM3qSUKmP_eMBG"]]
+
+    def __init__(self, root,
+                 transform=None,
+                 pre_transform=None,
+                 pre_filter=None,
+                 verbose=False,
+                 debug=False,
+                 num_pos_pairs=200,
+                 max_dist_overlap=0.01,
+                 self_supervised=False,
+                 min_size_block=2,
+                 max_size_block=3,
+                 min_points=500,
+                 ss_transform=None):
+        self.link_pairs = "https://cloud.mines-paristech.fr/index.php/s/yjd20Ih9ExqLlHM/download"
+        
+        BasePCRBTest.__init__(self,
+                              root=root,
+                              transform=transform,
+                              pre_transform=pre_transform,
+                              pre_filter=pre_filter,
+                              verbose=verbose, debug=debug,
+                              max_dist_overlap=max_dist_overlap,
+                              num_pos_pairs=num_pos_pairs,
+                              self_supervised=self_supervised,
+                              min_size_block=min_size_block,
+                              max_size_block=max_size_block,
+                              min_points=min_points,
+                              ss_transform=ss_transform)
+
+    def download(self):
+        folder = os.path.join(self.raw_dir, "test")
+        if files_exist([folder]):  # pragma: no cover
+            log.warning("already downloaded {}".format("test"))
+            return
+        else:
+            makedirs(folder)
+        log.info("Download elements in the file {}...".format(folder))
+        for name, url in self.DATASETS:
+            dataset_folder = os.path.join(folder,name)
+            os.mkdir(dataset_folder)
+            log.info(f'Downloading sequence {name}')
+            filename = os.path.join(folder,name+".zip")
+            gdown.download(url, filename, quiet=False)
+            with ZipFile(filename, 'r') as zip_obj:
+                zip_obj.extractall(dataset_folder)
+            os.remove(filename)
+
+        self.download_pairs(folder)
+
+
+class TUMDataset(BaseSiameseDataset):
+    """
+    this class is a dataset for testing registration algorithm on the TUM RGB-D Dataset
+    https://vision.in.tum.de/data/datasets/rgbd-dataset    
+    as defined in https://github.com/iralabdisco/point_clouds_registration_benchmark.
+    """
+
+
+    def __init__(self, dataset_opt):
+
+        super().__init__(dataset_opt)
+        pre_transform = self.pre_transform
+        train_transform = self.train_transform
+        ss_transform = getattr(self, "ss_transform", None)
+        test_transform = self.test_transform
+
+        # training is similar to test but only unsupervised training is allowed XD
+        self.train_dataset = TestPairTUM(root=self._data_path,
+                                         pre_transform=pre_transform,
+                                         transform=train_transform,
+                                         max_dist_overlap=dataset_opt.max_dist_overlap,
+                                         self_supervised=True,
+                                         min_size_block=dataset_opt.min_size_block,
+                                         max_size_block=dataset_opt.max_size_block,
+                                         num_pos_pairs=dataset_opt.num_pos_pairs,
+                                         min_points=dataset_opt.min_points,
+                                         ss_transform=ss_transform)
+        self.test_dataset = TestPairTUM(root=self._data_path,
+                                        pre_transform=pre_transform,
+                                        transform=test_transform,
+                                        max_dist_overlap=dataset_opt.max_dist_overlap,
+                                        num_pos_pairs=dataset_opt.num_pos_pairs,
+                                        self_supervised=False)


### PR DESCRIPTION
Add Kaist and TUM datasets, as defined in https://arxiv.org/abs/2003.12841, similarly to what we have done for the ETH and Planetary datasets.