### PR TITLE
get rid of warning

### DIFF
--- a/torch_points3d/datasets/panoptic/utils.py
+++ b/torch_points3d/datasets/panoptic/utils.py
@@ -30,7 +30,7 @@ def set_extra_labels(data, instance_classes, num_max_objects):
             min_pos = pos.min(0)[0]
             center = 0.5 * (min_pos + max_pox)
             point_votes[ind, :] = center - pos
-            centers.append(torch.tensor(center))
+            centers.append(center.clone().detach())
             instance_labels[ind] = instance_idx
             instance_idx += 1
 


### PR DESCRIPTION
I got this warning when training panoptic segmentation on S3DIS:

`points3d/torch_points3d/datasets/panoptic/utils.py:33: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor)`

So I modified that line.