### PR TITLE
Fix ShapeNet segmentation with SparseConv3D models

### DIFF
--- a/conf/data/segmentation/shapenet_sparse.yaml
+++ b/conf/data/segmentation/shapenet_sparse.yaml
@@ -15,18 +15,18 @@ data:
         clip: 0.05
     - transform: GridSampling3D
       params:
-        grid_size: ${data.grid_size}
+        size: ${data.grid_size}
         mode: "mean"
         quantize_coords: True
   test_transforms:
     - transform: GridSampling3D
       params:
-        grid_size: ${data.grid_size}
+        size: ${data.grid_size}
         quantize_coords: True
         mode: "mean"
   val_transforms:
     - transform: GridSampling3D
       params:
-        grid_size: ${data.grid_size}
+        size: ${data.grid_size}
         quantize_coords: True
         mode: "mean"

--- a/torch_points3d/models/segmentation/pvcnn.py
+++ b/torch_points3d/models/segmentation/pvcnn.py
@@ -24,6 +24,7 @@ class PVCNN(BaseModel):
         if data.batch.dim() == 1:
             data.batch = data.batch.unsqueeze(-1)
         coords = torch.cat([data.pos, data.batch], -1)
+        self.batch_idx = data.batch.squeeze()
         self.input = SparseTensor(data.x, coords).to(self.device)
         self.labels = data.y.to(self.device)
 

--- a/torch_points3d/models/segmentation/sparseconv3d.py
+++ b/torch_points3d/models/segmentation/sparseconv3d.py
@@ -23,6 +23,7 @@ class APIModel(BaseModel):
         self.loss_names = ["loss_seg"]
 
     def set_input(self, data, device):
+        self.batch_idx = data.batch.squeeze()
         self.input = data
         if data.y is not None:
             self.labels = data.y.to(self.device)


### PR DESCRIPTION
This PR fixes the issues described in issue #517. It enables one to run SpraseConv3D based models as follows:
```
python train.py task=segmentation model_type=sparseconv3d model_name=ResUNet32 dataset=shapenet_sparse
python train.py task=segmentation model_type=pvcnn model_name=PVCNN dataset=shapenet_sparse
``` 