### PR TITLE
Refine the usage of data loader with num_workers>0

### DIFF
--- a/torch_points3d/datasets/base_dataset.py
+++ b/torch_points3d/datasets/base_dataset.py
@@ -252,8 +252,11 @@ class BaseDataset:
         batch_collate_function = self.__class__._get_collate_function(
             conv_type, precompute_multi_scale, pre_batch_collate_transform
         )
+        num_workers = kwargs.get("num_workers", 0)
+        persistent_workers = (num_workers > 0)
         dataloader = partial(
-            torch.utils.data.DataLoader, collate_fn=batch_collate_function, worker_init_fn=np.random.seed
+            torch.utils.data.DataLoader, collate_fn=batch_collate_function, worker_init_fn=np.random.seed,
+            persistent_workers=persistent_workers
         )
         return dataloader(dataset, **kwargs)
 


### PR DESCRIPTION
Fix bugs of frequently occurred `Exception ignored in: function _MultiProcessingDataLoaderIter.__del__`. 
#443 
#452 
