### PR TITLE
SparseConv3D Mixed Precision Training Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrated to Hydra 1.0 and OmegaConf 2.1 **BREAKING any checkpoint created prior to that, in particular the model zoo**
 
+### Added
+
+- Mixed precision training support for SparseConv3D models with torchsparse backend (Requires torchsparse >= 1.3.0)
+
 ## 1.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ conv = sp3d.nn.Conv3d(10, 10)
 bn = sp3d.nn.BatchNorm(10)
 ```
 
-## Mixed Precision Training
+### Mixed Precision Training
 
 Mixed precision allows for lower memory on the GPU and slightly faster training times by performing the sparse convolution, pooling, and gradient ops in `float16`. Mixed precision training is currently supported for CUDA training on `SparseConv3d` networks with the [torchsparse](https://github.com/mit-han-lab/torchsparse) backend. To enable mixed precision, ensure you have the latest version of torchsparse with `pip install --upgrade git+https://github.com/mit-han-lab/torchsparse.git`. Then, set `training.enable_mixed=True` in your training configuration files. If all the conditions are met, when you start training you will see a log entry stating: 
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Please refer to our [documentation](https://torch-points3d.readthedocs.io/en/lat
 
 # 3D Sparse convolution support
 
-We currently support [Minkowski Engine](https://github.com/StanfordVL/MinkowskiEngine) > v0.5 and [torchsparse](https://github.com/mit-han-lab/torchsparse) as backends for sparse convolutions. Those packages need to be installed independently from Torch Points3d, please follow installation instructions and troubleshooting notes on the respective repositories. At the moment `MinkowskiEngine` [see here (thank you Chris Choy)](https://gist.github.com/chrischoy/d8e971daf8308aa1dcba1524bf1fd91a) demonstrates faster training. **Please be aware that `torchsparse` is still in beta and does not support CPU only.**
+We currently support [Minkowski Engine](https://github.com/StanfordVL/MinkowskiEngine) > v0.5 and [torchsparse](https://github.com/mit-han-lab/torchsparse) as backends for sparse convolutions. Those packages need to be installed independently from Torch Points3d, please follow installation instructions and troubleshooting notes on the respective repositories. At the moment `MinkowskiEngine` [see here (thank you Chris Choy)](https://gist.github.com/chrischoy/d8e971daf8308aa1dcba1524bf1fd91a) demonstrates faster training. **Please be aware that `torchsparse` is still in beta and does not support CPU only training.**
 
 Once you have setup one of those two sparse convolution framework you can start using are high level to define a unet backbone or simply an encoder:
 
@@ -155,6 +155,16 @@ sp3d.nn.set_backend("torchsparse")
 conv = sp3d.nn.Conv3d(10, 10)
 bn = sp3d.nn.BatchNorm(10)
 ```
+
+## Mixed Precision Training
+
+Mixed precision allows for lower memory on the GPU and slightly faster training times by performing the sparse convolution, pooling, and gradient ops in `float16`. Mixed precision training is currently supported for CUDA training on `SparseConv3d` networks with the [torchsparse](https://github.com/mit-han-lab/torchsparse) backend. To enable mixed precision, ensure you have the latest version of torchsparse with `pip install --upgrade git+https://github.com/mit-han-lab/torchsparse.git`. Then, set `training.enable_mixed=True` in your training configuration files. If all the conditions are met, when you start training you will see a log entry stating: 
+
+`[torch_points3d.models.base_model][INFO] - Model will use mixed precision`
+
+If, however, you try to use mixed precision training with an unsupported backend, you will see:
+
+`[torch_points3d.models.base_model][WARNING] - Mixed precision is not supported on this model, using default precision...`
 
 # Adding your model to the PretrainedRegistry.
 

--- a/conf/models/segmentation/sparseconv3d.yaml
+++ b/conf/models/segmentation/sparseconv3d.yaml
@@ -3,6 +3,7 @@ ResUNet32:
   class: sparseconv3d.APIModel
   conv_type: "SPARSE"
   backend: "torchsparse"
+  enable_mixed: True
   backbone:
     define_constants:
       in_feat: 32
@@ -40,6 +41,7 @@ Res16UNet34:
   class: sparseconv3d.APIModel
   conv_type: "SPARSE"
   backend: "torchsparse"
+  enable_mixed: True
   backbone:
     define_constants:
       in_feat: 32

--- a/conf/models/segmentation/sparseconv3d.yaml
+++ b/conf/models/segmentation/sparseconv3d.yaml
@@ -3,7 +3,6 @@ ResUNet32:
   class: sparseconv3d.APIModel
   conv_type: "SPARSE"
   backend: "torchsparse"
-  enable_mixed: True
   backbone:
     define_constants:
       in_feat: 32
@@ -41,7 +40,6 @@ Res16UNet34:
   class: sparseconv3d.APIModel
   conv_type: "SPARSE"
   backend: "torchsparse"
-  enable_mixed: True
   backbone:
     define_constants:
       in_feat: 32

--- a/conf/training/minkowski_scannet.yaml
+++ b/conf/training/minkowski_scannet.yaml
@@ -6,6 +6,7 @@ batch_size: 12
 shuffle: True
 cuda: 0
 precompute_multi_scale: False # Compute multiscate features on cpu for faster training / inference
+enable_mixed: True # Allow mixed precision on supported models
 optim:
   base_lr: 0.1
   # accumulated_gradient: -1 # Accumulate gradient accumulated_gradient * batch_size

--- a/conf/training/minkowski_scannet.yaml
+++ b/conf/training/minkowski_scannet.yaml
@@ -1,5 +1,5 @@
+# @package _global_
 # Ref: https://github.com/chrischoy/SpatioTemporalSegmentation/blob/master/config.py
-# @package training
 epochs: 500
 num_workers: 4
 batch_size: 12

--- a/docker/install_python.sh
+++ b/docker/install_python.sh
@@ -12,11 +12,11 @@ if [ $1 == "gpu" ]; then
     echo "Install GPU"
     pip3 install torch==1.7.0 torchvision==0.8.1
     pip3 install MinkowskiEngine --install-option="--force_cuda" --install-option="--cuda_home=/usr/local/cuda"
-    pip3 install git+https://github.com/mit-han-lab/torchsparse.git@f79df704e2fb3ea912c31d57e910ea0edba03da4 -v
+    pip3 install git+https://github.com/mit-han-lab/torchsparse.git@96859d6d0a54b29420a0d4e39f300de49c4ff77a -v
     pip3 install pycuda
 else
     echo "Install CPU"
     pip3 install torch==1.7.0+cpu torchvision==0.8.1+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pip3 install MinkowskiEngine
-    pip3 install git+https://github.com/mit-han-lab/torchsparse.git@f79df704e2fb3ea912c31d57e910ea0edba03da4
+    pip3 install git+https://github.com/mit-han-lab/torchsparse.git@96859d6d0a54b29420a0d4e39f300de49c4ff77a
 fi

--- a/torch_points3d/applications/sparseconv3d.py
+++ b/torch_points3d/applications/sparseconv3d.py
@@ -56,7 +56,11 @@ def SparseConv3d(
      backend:
          torchsparse or minkowski
     """
-    sp3d.nn.set_backend(backend)
+    if "SPARSE_BACKEND" in os.environ and sp3d.nn.backend_valid(os.environ["SPARSE_BACKEND"]):
+        sp3d.nn.set_backend(os.environ["SPARSE_BACKEND"])
+    else:
+        sp3d.nn.set_backend(backend)
+    
     factory = SparseConv3dFactory(
         architecture=architecture, num_layers=num_layers, input_nc=input_nc, config=config, **kwargs
     )

--- a/torch_points3d/models/base_model.py
+++ b/torch_points3d/models/base_model.py
@@ -233,15 +233,10 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         with torch.cuda.amp.autocast(enabled=self.is_mixed_precision()): # enable autocasting if supported
             self.forward(epoch=epoch)  # first call forward to calculate intermediate results
         
-        # print(self.is_mixed_precision())
-        # print(self.loss_seg)
         orig_losses = self._do_scale_loss() # scale losses if needed
-        # print(orig_losses)
-        # print(self.loss_seg)
         make_optimizer_step = self._manage_optimizer_zero_grad()  # Accumulate gradient if option is up
         self.backward()  # calculate gradients
         self._do_unscale_loss(orig_losses) # unscale losses to orig
-        # print(self.loss_seg)
 
         if self._grad_clip > 0:
             self._grad_scale.unscale_(self._optimizer) # unscale gradients before clipping

--- a/torch_points3d/models/base_model.py
+++ b/torch_points3d/models/base_model.py
@@ -132,7 +132,7 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         self._conv_type = conv_type
         
     def is_mixed_precision(self):
-        return self._supports_mixed && self._enable_mixed
+        return self._supports_mixed and self._enable_mixed
 
     def set_input(self, input, device):
         """Unpack input data from the dataloader and perform necessary pre-processing steps.

--- a/torch_points3d/models/base_model.py
+++ b/torch_points3d/models/base_model.py
@@ -5,7 +5,6 @@ import os
 import torch
 from torch.optim.optimizer import Optimizer
 from torch.optim.lr_scheduler import _LRScheduler
-from torch.cuda.amp import GradScaler, autocast
 import logging
 from collections import defaultdict
 from torch_points3d.core.schedulers.lr_schedulers import instantiate_scheduler
@@ -230,7 +229,7 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
     def optimize_parameters(self, epoch, batch_size):
         """Calculate losses, gradients, and update network weights; called in every training iteration"""
 
-        with autocast(enabled=self.is_mixed_precision()): # enable autocasting if supported
+        with torch.cuda.amp.autocast(enabled=self.is_mixed_precision()): # enable autocasting if supported
             self.forward(epoch=epoch)  # first call forward to calculate intermediate results
         
         # print(self.is_mixed_precision())
@@ -325,7 +324,7 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         elif self.is_mixed_precision():
             log.info("Model will use mixed precision")
 
-        self._grad_scale = GradScaler(enabled=self.is_mixed_precision())
+        self._grad_scale = torch.cuda.amp.GradScaler(enabled=self.is_mixed_precision())
 
     def get_regularization_loss(self, regularizer_type="L2", **kwargs):
         loss = 0

--- a/torch_points3d/models/base_model.py
+++ b/torch_points3d/models/base_model.py
@@ -62,6 +62,7 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         self._grad_clip = -1
         self._grad_scale = None
         self._supports_mixed = False
+        self._enable_mixed = False
         self._update_lr_scheduler_on = "on_epoch"
         self._update_bn_scheduler_on = "on_epoch"
 

--- a/torch_points3d/models/base_model.py
+++ b/torch_points3d/models/base_model.py
@@ -63,7 +63,6 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         self._grad_clip = -1
         self._grad_scale = None
         self._supports_mixed = False
-        self._enable_mixed = False
         self._update_lr_scheduler_on = "on_epoch"
         self._update_bn_scheduler_on = "on_epoch"
 
@@ -320,6 +319,12 @@ class BaseModel(torch.nn.Module, TrackerInterface, DatasetInterface, CheckpointI
         self._grad_clip = self.get_from_opt(config, ["training", "optim", "grad_clip"], default_value=-1)
 
         # Gradient Scaling
+        self._enable_mixed = self.get_from_opt(config, ["training", "enable_mixed"], default_value=False)
+        if self._enable_mixed and not self.is_mixed_precision():
+            log.warning("Mixed precision is not supported on this model, using default precision...")
+        elif self.is_mixed_precision():
+            log.info("Model will use mixed precision")
+
         self._grad_scale = GradScaler(enabled=self.is_mixed_precision())
 
     def get_regularization_loss(self, regularizer_type="L2", **kwargs):

--- a/torch_points3d/models/segmentation/sparseconv3d.py
+++ b/torch_points3d/models/segmentation/sparseconv3d.py
@@ -22,7 +22,7 @@ class APIModel(BaseModel):
         self.backbone = SparseConv3d(
             "unet", dataset.feature_dimension, config=option.backbone, backend=option.get("backend", "minkowski")
         )
-        self._supports_mixed = sp3d.nn.backend == "torchsparse"
+        self._supports_mixed = sp3d.nn.get_backend() == "torchsparse"
         self.head = nn.Sequential(nn.Linear(self.backbone.output_nc, dataset.num_classes))
         self.loss_names = ["loss_seg"]
 

--- a/torch_points3d/models/segmentation/sparseconv3d.py
+++ b/torch_points3d/models/segmentation/sparseconv3d.py
@@ -7,6 +7,7 @@ import torchsparse as TS
 from torch_points3d.models.base_model import BaseModel
 from torch_points3d.datasets.segmentation import IGNORE_LABEL
 from torch_points3d.applications.sparseconv3d import SparseConv3d
+import torch_points3d.modules.SparseConv3d as sp3d
 
 from torch_points3d.core.common_modules import FastBatchNorm1d, Seq
 
@@ -21,6 +22,8 @@ class APIModel(BaseModel):
         self.backbone = SparseConv3d(
             "unet", dataset.feature_dimension, config=option.backbone, backend=option.get("backend", "minkowski")
         )
+        self._supports_mixed = sp3d.nn.backend == "torchsparse"
+        self._enable_mixed = option.enable_mixed
         self.head = nn.Sequential(nn.Linear(self.backbone.output_nc, dataset.num_classes))
         self.loss_names = ["loss_seg"]
 
@@ -34,6 +37,7 @@ class APIModel(BaseModel):
 
     def forward(self, *args, **kwargs):
         features = self.backbone(self.input).x
+        # print(features.dtype)
         logits = self.head(features)
         self.output = F.log_softmax(logits, dim=-1)
         if self._weight_classes is not None:

--- a/torch_points3d/models/segmentation/sparseconv3d.py
+++ b/torch_points3d/models/segmentation/sparseconv3d.py
@@ -23,7 +23,6 @@ class APIModel(BaseModel):
             "unet", dataset.feature_dimension, config=option.backbone, backend=option.get("backend", "minkowski")
         )
         self._supports_mixed = sp3d.nn.backend == "torchsparse"
-        self._enable_mixed = option.enable_mixed
         self.head = nn.Sequential(nn.Linear(self.backbone.output_nc, dataset.num_classes))
         self.loss_names = ["loss_seg"]
 
@@ -37,7 +36,7 @@ class APIModel(BaseModel):
 
     def forward(self, *args, **kwargs):
         features = self.backbone(self.input).x
-        # print(features.dtype)
+        print(features.dtype)
         logits = self.head(features)
         self.output = F.log_softmax(logits, dim=-1)
         if self._weight_classes is not None:

--- a/torch_points3d/models/segmentation/sparseconv3d.py
+++ b/torch_points3d/models/segmentation/sparseconv3d.py
@@ -36,7 +36,6 @@ class APIModel(BaseModel):
 
     def forward(self, *args, **kwargs):
         features = self.backbone(self.input).x
-        print(features.dtype)
         logits = self.head(features)
         self.output = F.log_softmax(logits, dim=-1)
         if self._weight_classes is not None:

--- a/torch_points3d/modules/SparseConv3d/nn/__init__.py
+++ b/torch_points3d/modules/SparseConv3d/nn/__init__.py
@@ -22,6 +22,12 @@ __all__ = ["cat", "Conv3d", "Conv3dTranspose", "ReLU", "SparseTensor", "BatchNor
 for val in __all__:
     exec(val + "=None")
 
+def backend_valid(_backend):
+    return _backend in {"torchsparse", "minkowski"}
+
+sp3d_backend = ""
+def get_backend():
+    return sp3d_backend
 
 def set_backend(_backend):
     """ Use this method to switch sparse backend dynamically. When importing this module with a wildcard such as
@@ -34,19 +40,11 @@ def set_backend(_backend):
     backend : str
         "torchsparse" or "minkowski"
     """
-    assert _backend in {"torchsparse", "minkowski"}
+    assert backend_valid(_backend)
     try:
         modules = importlib.import_module("." + _backend, __name__)  # noqa: F841
-        backend = _backend
+        sp3d_backend = _backend
     except:
         log.exception("Could not import %s backend for sparse convolutions" % _backend)
     for val in __all__:
         exec("globals()['%s'] = modules.%s" % (val, val))
-
-
-if "SPARSE_BACKEND" in os.environ:
-    backend = os.environ["SPARSE_BACKEND"]
-else:
-    backend = "minkowski"
-
-set_backend(backend)

--- a/torch_points3d/modules/SparseConv3d/nn/__init__.py
+++ b/torch_points3d/modules/SparseConv3d/nn/__init__.py
@@ -25,7 +25,8 @@ for val in __all__:
 def backend_valid(_backend):
     return _backend in {"torchsparse", "minkowski"}
 
-sp3d_backend = ""
+sp3d_backend = None
+
 def get_backend():
     return sp3d_backend
 
@@ -43,6 +44,7 @@ def set_backend(_backend):
     assert backend_valid(_backend)
     try:
         modules = importlib.import_module("." + _backend, __name__)  # noqa: F841
+        global sp3d_backend
         sp3d_backend = _backend
     except:
         log.exception("Could not import %s backend for sparse convolutions" % _backend)

--- a/torch_points3d/modules/SparseConv3d/nn/__init__.py
+++ b/torch_points3d/modules/SparseConv3d/nn/__init__.py
@@ -23,7 +23,7 @@ for val in __all__:
     exec(val + "=None")
 
 
-def set_backend(backend):
+def set_backend(_backend):
     """ Use this method to switch sparse backend dynamically. When importing this module with a wildcard such as
     from torch_points3d.modules.SparseConv3d.nn import *
     make sure that you import it again after calling this method.
@@ -34,11 +34,12 @@ def set_backend(backend):
     backend : str
         "torchsparse" or "minkowski"
     """
-    assert backend in {"torchsparse", "minkowski"}
+    assert _backend in {"torchsparse", "minkowski"}
     try:
-        modules = importlib.import_module("." + backend, __name__)  # noqa: F841
+        modules = importlib.import_module("." + _backend, __name__)  # noqa: F841
+        backend = _backend
     except:
-        log.exception("Could not import %s backend for sparse convolutions" % backend)
+        log.exception("Could not import %s backend for sparse convolutions" % _backend)
     for val in __all__:
         exec("globals()['%s'] = modules.%s" % (val, val))
 

--- a/torch_points3d/trainer.py
+++ b/torch_points3d/trainer.py
@@ -246,7 +246,8 @@ class Trainer:
                     for data in tq_loader:
                         with torch.no_grad():
                             self._model.set_input(data, self._device)
-                            self._model.forward(epoch=epoch)
+                            with torch.cuda.amp.autocast(enabled=self._model.is_mixed_precision()):
+                                self._model.forward(epoch=epoch)
                             self._tracker.track(self._model, data=data, **self.tracker_options)
                         tq_loader.set_postfix(**self._tracker.get_metrics(), color=COLORS.TEST_COLOR)
 

--- a/torch_points3d/trainer.py
+++ b/torch_points3d/trainer.py
@@ -90,7 +90,7 @@ class Trainer:
         else:
             self._dataset: BaseDataset = instantiate_dataset(self._cfg.data)
             self._model: BaseModel = instantiate_model(copy.deepcopy(self._cfg), self._dataset)
-            self._model.instantiate_optimizers(self._cfg)
+            self._model.instantiate_optimizers(self._cfg, "cuda" in device)
             self._model.set_pretrained_weights()
             if not self._checkpoint.validate(self._dataset.used_properties):
                 log.warning(


### PR DESCRIPTION
I added support for mixed-precision training in torchsparse (https://github.com/mit-han-lab/torchsparse/pull/69) with the following results:

> The performance of the mixed-precision training is almost the same as that of the full-precision training: 76.43 v.s. 76.78.
> The speedup is fairly limited: the total training time is reduced from 7.3 hours to 6.4 hours (around 10% reduction).
> The memory reduction is very significant: the memory usage is reduced from 48.8G to 28.8G (40% reduction).

With these commits, I added a `training.enable_mixed` flag which enables the usage of mixed precision on supported models, as well as a `_supports_mixed` variable to the models which support mixed precision (sp3d with torchsparse backend). 

To actually activate mixed precision, I wrapped the training in `torch.cuda.amp.autocast` and added a loss scaler `torch.cuda.amp.GradScaler`.

I'm running experiments on s3dis which you can find here: https://wandb.ai/allcowseatfood/s3dis 
You can see the mixed precision training has lower memory usage than regular training and autocasted minkowskiengine. 

![image](https://user-images.githubusercontent.com/2824685/120697711-ae54ac80-c473-11eb-92f3-541f9b950aa7.png)
